### PR TITLE
Dynamic query projection

### DIFF
--- a/sample/SampleApp/Requests/Books.http
+++ b/sample/SampleApp/Requests/Books.http
@@ -1,7 +1,11 @@
 @baseUrl=http://localhost:5117
 @bookId=1
 
-GET {{baseUrl}}/books
+GET {{baseUrl}}/books?property
+
+###
+
+GET {{baseUrl}}/books?property=title
 
 ###
 

--- a/sample/SampleApp/Services/BitzArt.CA.SampleApp.WebApi/Controllers/BooksController.cs
+++ b/sample/SampleApp/Services/BitzArt.CA.SampleApp.WebApi/Controllers/BooksController.cs
@@ -7,10 +7,20 @@ namespace BitzArt.CA.SampleApp;
 public class BooksController(IBookRepository bookRepository) : ControllerBase
 {
     [HttpGet]
-    public async Task<IActionResult> GetAllAsync()
+    public async Task<IActionResult> GetAllAsync([FromQuery(Name = "property")] string property)
     {
-        var books = await bookRepository.GetAllAsync();
-        return Ok(books);
+        var result = await bookRepository.GetAllAsync(q =>
+        {
+            // showcasing dynamic query projection
+            if (string.Equals(property, "title", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return q.Select(book => book.Title);
+            }
+
+            return q;
+        });
+
+        return Ok(result);
     }
 
     [HttpGet("{id:int}")]

--- a/sample/SampleApp/Services/BitzArt.CA.SampleApp.WebApi/Controllers/BooksController.cs
+++ b/sample/SampleApp/Services/BitzArt.CA.SampleApp.WebApi/Controllers/BooksController.cs
@@ -7,7 +7,7 @@ namespace BitzArt.CA.SampleApp;
 public class BooksController(IBookRepository bookRepository) : ControllerBase
 {
     [HttpGet]
-    public async Task<IActionResult> GetAllAsync([FromQuery(Name = "property")] string property)
+    public async Task<IActionResult> GetAllAsync([FromQuery(Name = "property")] string? property)
     {
         var result = await bookRepository.GetAllAsync(q =>
         {

--- a/src/BitzArt.CA.Core/Interfaces/IRepository.cs
+++ b/src/BitzArt.CA.Core/Interfaces/IRepository.cs
@@ -54,6 +54,9 @@ public interface IRepository<TEntity> : IRepository
     /// <inheritdoc cref="GetAllAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<IEnumerable<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
 
+    /// <inheritdoc cref="GetAllAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<IEnumerable<object>> GetAllAsync(Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Retrieves all records of type <typeparamref name="TEntity"/> from the repository.
     /// </summary>
@@ -81,6 +84,10 @@ public interface IRepository<TEntity> : IRepository
 
     /// <inheritdoc cref="GetPageAsync{TPageRequest, TResult}(TPageRequest, Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<PageResult<TEntity, TPageRequest>> GetPageAsync<TPageRequest>(TPageRequest pageRequest, CancellationToken cancellationToken = default)
+        where TPageRequest : IPageRequest;
+
+    /// <inheritdoc cref="GetPageAsync{TPageRequest, TResult}(TPageRequest, Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<PageResult<object, TPageRequest>> GetPageAsync<TPageRequest>(TPageRequest pageRequest, Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default)
         where TPageRequest : IPageRequest;
 
     /// <summary>
@@ -114,6 +121,9 @@ public interface IRepository<TEntity> : IRepository
     /// <inheritdoc cref="FirstAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<TEntity> FirstAsync(CancellationToken cancellationToken = default);
 
+    /// <inheritdoc cref="FirstAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<object> FirstAsync(Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Retrieves the first matching record of type <typeparamref name="TResult"/> from the repository.
     /// </summary>
@@ -125,6 +135,9 @@ public interface IRepository<TEntity> : IRepository
 
     /// <inheritdoc cref="FirstOrDefaultAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<TEntity?> FirstOrDefaultAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="FirstOrDefaultAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<object?> FirstOrDefaultAsync(Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the first matching record of type <typeparamref name="TResult"/> from the repository,
@@ -138,6 +151,9 @@ public interface IRepository<TEntity> : IRepository
 
     /// <inheritdoc cref="SingleAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<TEntity> SingleAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="SingleAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<object> SingleAsync(Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// <para>
@@ -155,6 +171,9 @@ public interface IRepository<TEntity> : IRepository
 
     /// <inheritdoc cref="SingleOrDefaultAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
     public Task<TEntity?> SingleOrDefaultAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="SingleOrDefaultAsync{TResult}(Func{IQueryable{TEntity}, IQueryable{TResult}}, CancellationToken)"/>
+    public Task<object?> SingleOrDefaultAsync(Func<IQueryable<TEntity>, IQueryable> filter, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// <para>

--- a/tests/BitzArt.CA.TestApp/Controllers/TestController.cs
+++ b/tests/BitzArt.CA.TestApp/Controllers/TestController.cs
@@ -8,8 +8,8 @@ public class TestController(ILogger<TestController> logger) : ControllerBase
     [HttpGet]
     public IActionResult TestGet()
     {
-        /*logger.LogInformation("TestGet");
-        return Ok("OK");*/
+        logger.LogInformation("TestGet");
+        return Ok("OK");
     }
 
     [HttpPost]

--- a/tests/BitzArt.CA.TestApp/Controllers/TestController.cs
+++ b/tests/BitzArt.CA.TestApp/Controllers/TestController.cs
@@ -8,8 +8,8 @@ public class TestController(ILogger<TestController> logger) : ControllerBase
     [HttpGet]
     public IActionResult TestGet()
     {
-        logger.LogInformation("TestGet");
-        return Ok("OK");
+        /*logger.LogInformation("TestGet");
+        return Ok("OK");*/
     }
 
     [HttpPost]


### PR DESCRIPTION
This pull request introduces dynamic query projection capabilities and refactors repository methods to support flexible filtering. The changes include updates to the `BooksController` in the sample app to showcase handling query parameters for dynamic projections, modifications to repository interfaces and implementations to support generic filtering, and cleanup of unused methods.

### Dynamic Query Projection

* [`src/BitzArt.CA.Core/Interfaces/IRepository.cs`](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR57-R59): Added new overloads for repository methods (`GetAllAsync`, `GetPageAsync`, `FirstAsync`, `FirstOrDefaultAsync`, `SingleAsync`, `SingleOrDefaultAsync`) to support filtering using `Func<IQueryable<TEntity>, IQueryable>`. [[1]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR57-R59) [[2]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR89-R92) [[3]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR124-R126) [[4]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR139-R141) [[5]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR155-R157) [[6]](diffhunk://#diff-4178b0ee8150eb512bac4cd228c76caa43c560b81d7c88f32a7d6659e7a8481aR175-R177)
* [`src/BitzArt.CA.Persistence.EntityFrameworkCore/Repositories/AppDbRepository.cs`](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R73-R81): Implemented the new filtering methods in the repository, enabling dynamic query projection. [[1]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R73-R81) [[2]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R121-R130) [[3]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R168-R176) [[4]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R195-R203) [[5]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R222-R230) [[6]](diffhunk://#diff-23e8109f14779cfa023d0b2bcd86e4206b859add5ea896437cdddb118e1bc823R249-R257)

### Sample App

* [`sample/SampleApp/Requests/Books.http`](diffhunk://#diff-11415b7baae6a8f89b9b09f40ec2468e2278a345985125726fd66ed265af0aaaL4-R8): Added new query parameter `property` to filter books by specific attributes, such as `title`.
* [`sample/SampleApp/Services/BitzArt.CA.SampleApp.WebApi/Controllers/BooksController.cs`](diffhunk://#diff-5220f4b3dfdc1d09b33b2f891635241c81e7eea886103ffc021d39956c7428deL10-R23): Updated `GetAllAsync` method to accept a `property` query parameter and dynamically project query results based on the specified property.